### PR TITLE
Retort examples arent strict

### DIFF
--- a/examples/space-station-locator.rt.mjs
+++ b/examples/space-station-locator.rt.mjs
@@ -7,7 +7,7 @@ const getCoordinates = async function () {
       'https://api.wheretheiss.at/v1/satellites/25544'
     );
     const data = await response.json();
-    return [data.longitude, data.latitude];
+    return [data["longitude"], data["latitude"]];
   } catch (err) {
     console.log("Couldn't fetch coordinates", err);
     throw err;

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -12,17 +12,7 @@
     "allowJs": true,
     "checkJs": true,
 
-    "strict": true,
-    "strictNullChecks": true,
-    "noImplicitAny": false,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "noImplicitThis": true,
-    "noImplicitReturns": true,
-    "alwaysStrict": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
+    "strict": false,
 
     "skipLibCheck": true
   }


### PR DESCRIPTION
Loosened up typecript type checking on the retort examples.